### PR TITLE
denoify

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1,17 +1,17 @@
-import { ErrorLike } from './schema/errors';
+import { ErrorLike } from './schema/errors.ts';
 import {
   MergeSchemaParameters,
   SchemaParameters,
   SchemaResolveType,
   SchemaReturnType,
   SchemaValidatorFunction,
-} from './schema/io';
-import Validator, { ValidatorProxy } from './Validator';
-import compiler from './schema/compiler';
-import { either as eitherSchema, merge as mergeSchemas } from './schema/logic';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { Enum } from './schema/utils';
-import { enumValue } from './schema/validations';
+} from './schema/io.ts';
+import Validator, { ValidatorProxy } from './Validator.ts';
+import compiler from './schema/compiler.ts';
+import { either as eitherSchema, merge as mergeSchemas } from './schema/logic.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { Enum } from './schema/utils.ts';
+import { enumValue } from './schema/validations.ts';
 
 interface SchemaType {
   <S>(schema: S, error?: ErrorLike<SchemaParameters<S>>): ValidatorProxy<

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,9 +1,9 @@
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { ErrorLike } from './schema/errors';
-import { destruct, equals, error, test } from './schema/validations';
-import { isPromiseLike, MaybeAsync, ResolvedValue } from './schema/utils';
-import { optional as optionalSchema } from './schema/logic';
-import { MergeSchemaParameters } from './schema/io';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { ErrorLike } from './schema/errors.ts';
+import { destruct, equals, error, test } from './schema/validations.ts';
+import { isPromiseLike, MaybeAsync, ResolvedValue } from './schema/utils.ts';
+import { optional as optionalSchema } from './schema/logic.ts';
+import { MergeSchemaParameters } from './schema/io.ts';
 
 export type ValidatorProxy<
   V extends { validator: FunctionType },

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,14 +1,14 @@
-import Validator, { ValidatorProxy } from './Validator';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { array as arrayValidator } from './schema/validations';
-import { ErrorLike } from './schema/errors';
+import Validator, { ValidatorProxy } from './Validator.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { array as arrayValidator } from './schema/validations.ts';
+import { ErrorLike } from './schema/errors.ts';
 import {
   SchemaParameters,
   SchemaResolveType,
   SchemaReturnType,
-} from './schema/io';
-import compiler from './schema/compiler';
-import { isPromiseLike, ResolvedValue } from './schema/utils';
+} from './schema/io.ts';
+import compiler from './schema/compiler.ts';
+import { isPromiseLike, ResolvedValue } from './schema/utils.ts';
 
 export class ArrayValidator<
   R extends unknown[] | PromiseLike<unknown[]> = unknown[],

--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -1,6 +1,6 @@
-import Validator from './Validator';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { type } from './schema/validations';
+import Validator from './Validator.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { type } from './schema/validations.ts';
 
 export class BooleanValidator<
   P extends FunctionParameters = [boolean]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
-import unknown from './unknown';
-import object from './object';
-import array from './array';
-import string from './string';
-import number from './number';
-import boolean from './boolean';
-import Schema from './Schema';
+import unknown from './unknown.ts';
+import object from './object.ts';
+import array from './array.ts';
+import string from './string.ts';
+import number from './number.ts';
+import boolean from './boolean.ts';
+import Schema from './Schema.ts';
 import {
   SchemaResolveType,
   SchemaParameters,
   MergeSchemaParameters,
   SchemaReturnType,
   SchemaValidatorFunction,
-} from './schema/io';
-import { ValidationError, PathError } from './schema/errors';
-import { isPromiseLike, ResolvedValue } from './schema/utils';
+} from './schema/io.ts';
+import { ValidationError, PathError } from './schema/errors.ts';
+import { isPromiseLike, ResolvedValue } from './schema/utils.ts';
 
 // type generator
 export type Type<S> = SchemaResolveType<S>;

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,8 +1,8 @@
-import Validator, { ValidatorProxy } from './Validator';
-import { StringValidator } from './string';
-import { ErrorLike } from './schema/errors';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { type } from './schema/validations';
+import Validator, { ValidatorProxy } from './Validator.ts';
+import { StringValidator } from './string.ts';
+import { ErrorLike } from './schema/errors.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { type } from './schema/validations.ts';
 
 export class NumberValidator<
   P extends FunctionParameters = [number]

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,6 +1,6 @@
-import Validator from './Validator';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { type } from './schema/validations';
+import Validator from './Validator.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { type } from './schema/validations.ts';
 
 export class ObjectValidator<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/schema/compiler.ts
+++ b/src/schema/compiler.ts
@@ -2,12 +2,12 @@ import {
   SchemaParameters,
   SchemaResolveType,
   SchemaValidatorFunction,
-} from './io';
-import { createValidationError, ErrorLike, ObjectPath } from './errors';
-import { array, equals, regexp, type } from './validations';
-import FunctionType from './FunctionType';
-import { isPromiseLike } from './utils';
-import { PathError } from './errors';
+} from './io.ts';
+import { createValidationError, ErrorLike, ObjectPath } from './errors.ts';
+import { array, equals, regexp, type } from './validations.ts';
+import FunctionType from './FunctionType.ts';
+import { isPromiseLike } from './utils.ts';
+import { PathError } from './errors.ts';
 
 type SchemaKeyTask<S> = (
   res: Record<string, unknown>,

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -1,5 +1,5 @@
-import { FunctionParameters } from './FunctionType';
-import { ObjectProperty } from './utils';
+import { FunctionParameters } from './FunctionType.ts';
+import { ObjectProperty } from './utils.ts';
 
 export type ErrorLike<P extends FunctionParameters = never> =
   | string

--- a/src/schema/io.ts
+++ b/src/schema/io.ts
@@ -1,5 +1,5 @@
-import FunctionType, { FunctionParameters } from './FunctionType';
-import { IsAsync, Primitive, ResolvedValue } from './utils';
+import FunctionType, { FunctionParameters } from './FunctionType.ts';
+import { IsAsync, Primitive, ResolvedValue } from './utils.ts';
 
 type SchemaOptionalKeys<S> = Exclude<
   {

--- a/src/schema/logic.ts
+++ b/src/schema/logic.ts
@@ -3,11 +3,11 @@ import {
   SchemaParameters,
   SchemaResolveType,
   SchemaReturnType,
-} from './io';
-import FunctionType from './FunctionType';
-import compiler from './compiler';
-import { deepConcat, isPromiseLike } from './utils';
-import { findSwitchKey, generateSwitch } from './switch';
+} from './io.ts';
+import FunctionType from './FunctionType.ts';
+import compiler from './compiler.ts';
+import { deepConcat, isPromiseLike } from './utils.ts';
+import { findSwitchKey, generateSwitch } from './switch.ts';
 
 export function either<A>(
   ...candidates: [A]

--- a/src/schema/switch.ts
+++ b/src/schema/switch.ts
@@ -1,5 +1,5 @@
-import { isPrimitive, Primitive } from './utils';
-import FunctionType from './FunctionType';
+import { isPrimitive, Primitive } from './utils.ts';
+import FunctionType from './FunctionType.ts';
 
 export type SwitchKey = [string, Map<Primitive, number>];
 

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -1,5 +1,5 @@
-import FunctionType from './FunctionType';
-import { RemoveAsync } from './io';
+import FunctionType from './FunctionType.ts';
+import { RemoveAsync } from './io.ts';
 
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 

--- a/src/schema/validations.ts
+++ b/src/schema/validations.ts
@@ -1,12 +1,12 @@
-import { ErrorLike, toError } from './errors';
-import FunctionType, { FunctionParameters } from './FunctionType';
+import { ErrorLike, toError } from './errors.ts';
+import FunctionType, { FunctionParameters } from './FunctionType.ts';
 import {
   Enum,
   isPromiseLike,
   MaybeAsync,
   ResolvedValue,
   Typeof,
-} from './utils';
+} from './utils.ts';
 
 export function type<
   T extends keyof Typeof,

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,7 +1,7 @@
-import { ErrorLike } from './schema/errors';
-import Validator, { ValidatorProxy } from './Validator';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { regexp, type } from './schema/validations';
+import { ErrorLike } from './schema/errors.ts';
+import Validator, { ValidatorProxy } from './Validator.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { regexp, type } from './schema/validations.ts';
 
 export class StringValidator<
   P extends FunctionParameters = [string]

--- a/src/unknown.ts
+++ b/src/unknown.ts
@@ -1,15 +1,15 @@
-import Validator, { ValidatorProxy } from './Validator';
-import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { ErrorLike, toError } from './schema/errors';
-import { ObjectValidator } from './object';
-import { StringValidator } from './string';
-import { NumberValidator } from './number';
-import { BooleanValidator } from './boolean';
-import { SchemaResolveType } from './schema/io';
-import compiler from './schema/compiler';
-import { ArrayValidator } from './array';
-import { array, enumValue, type } from './schema/validations';
-import { Enum } from './schema/utils';
+import Validator, { ValidatorProxy } from './Validator.ts';
+import FunctionType, { FunctionParameters } from './schema/FunctionType.ts';
+import { ErrorLike, toError } from './schema/errors.ts';
+import { ObjectValidator } from './object.ts';
+import { StringValidator } from './string.ts';
+import { NumberValidator } from './number.ts';
+import { BooleanValidator } from './boolean.ts';
+import { SchemaResolveType } from './schema/io.ts';
+import compiler from './schema/compiler.ts';
+import { ArrayValidator } from './array.ts';
+import { array, enumValue, type } from './schema/validations.ts';
+import { Enum } from './schema/utils.ts';
 
 const BOOL_MAP = {
   true: true,


### PR DESCRIPTION
hi :smiley_cat: 

this pull request is trying to be a minimal fix for https://github.com/neuledge/computed-types/issues/30

unlike with `node` which attempts all possible file extensions for a module, imports in `deno` must have the file extension be explicit.

i didn't add explicit file extensions in the test files, since those are written to be consumed by `node`.