### PR TITLE
export types as types in order to work with deno 1.4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { isPromiseLike, ResolvedValue } from './schema/utils';
 export type Type<S> = SchemaResolveType<S>;
 
 // type helpers
-export {
+export type {
   ValidationError,
   PathError,
   SchemaParameters,


### PR DESCRIPTION
This fixes #62. All Tests are still passing despite of this change.