### PR TITLE
add overload for option argument to SchemaType

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -14,9 +14,15 @@ import { Enum } from './schema/utils';
 import { enumValue } from './schema/validations';
 
 interface SchemaType {
-  <S>(schema: S, error?: ErrorLike<SchemaParameters<S>>): ValidatorProxy<
-    Validator<SchemaValidatorFunction<S>>
-  >;
+  <S>(
+    schema: S,
+    opts?:
+      | ErrorLike<SchemaParameters<S>>
+      | {
+          error?: ErrorLike<SchemaParameters<S>>;
+          strict?: boolean;
+        },
+  ): ValidatorProxy<Validator<SchemaValidatorFunction<S>>>;
 
   either<A>(
     ...candidates: [A]


### PR DESCRIPTION
So, it seems like #78 was a misinterpretation on my part: there was no wrong code released, the type representation for `strict` was just never in the `SchemaType` interface, but only part of the underlying function definition.

This should fix that.