### PR TITLE
Support `Record<key, value>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,14 @@ enum Status {
 const validator = Schema.enum(Status, 'Invalid status');
 ```
 
+##### `Schema.record`
+
+Create a `Record<key, value>` validator.
+
+```ts
+const validator = Schema.record(string.regexp(/^[a-z]+$/), number);
+```
+
 <br>
 
 ### `unknown`
@@ -513,6 +521,14 @@ enum Status {
 }
 
 const validator = unknown.enum(Status);
+```
+
+##### `unknown.record()`
+
+Accept any value as an input and try to convert it to a `Record<key, value>`:
+
+```ts
+const validator = unknown.record(string, number);
 ```
 
 <br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "computed-types",
       "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -10,8 +10,8 @@ import Validator, { ValidatorProxy } from './Validator';
 import compiler from './schema/compiler';
 import { either as eitherSchema, merge as mergeSchemas } from './schema/logic';
 import FunctionType, { FunctionParameters } from './schema/FunctionType';
-import { Enum } from './schema/utils';
-import { enumValue } from './schema/validations';
+import { Enum, ObjectProperty } from './schema/utils';
+import { enumValue, recordValue } from './schema/validations';
 
 interface SchemaType {
   <S>(
@@ -335,6 +335,18 @@ interface SchemaType {
     value: E,
     error?: ErrorLike<P>,
   ): ValidatorProxy<Validator<FunctionType<E[keyof E], P>>>;
+
+  record<
+    K extends ObjectProperty,
+    V,
+    IK extends ObjectProperty,
+    IV,
+    P extends FunctionParameters = [Record<IK, IV>],
+  >(
+    key: FunctionType<K, [IK]>,
+    value: FunctionType<V, [IV]>,
+    error?: ErrorLike<P>,
+  ): ValidatorProxy<Validator<FunctionType<Record<K, V>, P>>>;
 }
 
 function schema<S>(
@@ -399,6 +411,20 @@ schema.enum = function <
   error?: ErrorLike<P>,
 ): ValidatorProxy<Validator<FunctionType<E[keyof E], P>>> {
   return new Validator(enumValue(value, error)).proxy();
+};
+
+schema.record = function <
+  K extends ObjectProperty,
+  V,
+  IK extends ObjectProperty,
+  IV,
+  P extends FunctionParameters = [Record<IK, IV>],
+>(
+  key: FunctionType<K, [IK]>,
+  value: FunctionType<V, [IV]>,
+  error?: ErrorLike<P>,
+): ValidatorProxy<Validator<FunctionType<Record<K, V>, P>>> {
+  return new Validator(recordValue(key, value, error)).proxy();
 };
 
 const Schema: SchemaType = schema;

--- a/src/unknown.test.ts
+++ b/src/unknown.test.ts
@@ -3,6 +3,8 @@ import { assert } from 'chai';
 import unknown from './unknown';
 import { typeCheck } from './schema/utils';
 import { ValidationError } from './schema/errors';
+import string from './string';
+import number from './number';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -164,5 +166,19 @@ describe('unknown', () => {
 
     assert.throws(() => validator(2), ValidationError);
     assert.throws(() => validator('Foo'), ValidationError);
+  });
+
+  it('.record()', () => {
+    const validator = unknown.record(string, number);
+
+    typeCheck<ReturnType<typeof validator>, Record<string, number>>('ok');
+    typeCheck<Parameters<typeof validator>, [unknown]>('ok');
+
+    assert.deepEqual(validator({ foo: 1 }), { foo: 1 });
+    assert.deepEqual(validator({}), {});
+
+    assert.throws(() => validator(2), ValidationError);
+    assert.throws(() => validator('Foo'), ValidationError);
+    assert.throws(() => validator({ foo: 'foo' }), ValidationError);
   });
 });

--- a/src/unknown.ts
+++ b/src/unknown.ts
@@ -8,8 +8,8 @@ import { BooleanValidator } from './boolean';
 import { SchemaResolveType } from './schema/io';
 import compiler from './schema/compiler';
 import { ArrayValidator } from './array';
-import { array, enumValue, type } from './schema/validations';
-import { Enum } from './schema/utils';
+import { array, enumValue, recordValue, type } from './schema/validations';
+import { Enum, ObjectProperty } from './schema/utils';
 import { DateValidator } from './DateType';
 
 const BOOL_MAP = {
@@ -134,6 +134,14 @@ export class UnknownValidator<
     error?: ErrorLike<[unknown]>,
   ): ValidatorProxy<Validator<FunctionType<E[keyof E], P>>> {
     return this.transform(enumValue(value, error), Validator);
+  }
+
+  public record<K extends ObjectProperty, V>(
+    key: FunctionType<K, [any]>, // eslint-disable-line @typescript-eslint/no-explicit-any
+    value: FunctionType<V, [any]>, // eslint-disable-line @typescript-eslint/no-explicit-any
+    error?: ErrorLike<[unknown]>,
+  ): ValidatorProxy<Validator<FunctionType<Record<K, V>, P>>> {
+    return this.transform(recordValue(key, value, error), Validator);
   }
 }
 


### PR DESCRIPTION
Add support for `Schema.record(key, value)` and `unknown.record(key, value)`.

Will solve #43 